### PR TITLE
added adb_commands.StreamingShell

### DIFF
--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -222,6 +222,20 @@ class AdbCommands(object):
         self.handle, service='shell', command=command,
         timeout_ms=timeout_ms)
 
+  def StreamingShell(self, command, timeout_ms=None):
+    """Run command on the device, yielding each line of output.
+
+    Args:
+      command: the command to run on the target.
+      timeout_ms: Maximum time to allow the command to run.
+
+    Yields:
+      The responses from the shell command.
+    """
+    return self.protocol_handler.StreamingCommand(
+        self.handle, service='shell', command=command,
+        timeout_ms=timeout_ms)
+
   def Logcat(self, options, timeout_ms=None):
     """Run 'shell logcat' and stream the output to stdout."""
     return self.protocol_handler.StreamingCommand(

--- a/adb_test.py
+++ b/adb_test.py
@@ -113,6 +113,21 @@ class AdbTest(BaseAdbTest):
     adb_commands = self._Connect(usb)
     self.assertEqual(''.join(responses), adb_commands.Shell(command))
 
+  def testStreamingResponseShell(self):
+    command = 'keepin it real big'
+    # expect multiple lines
+
+    responses = ['other stuff, ', 'and some words.']
+
+    usb = self._ExpectCommand('shell', command, *responses)
+
+    adb_commands = self._Connect(usb)
+    response_count = 0
+    for (expected,actual) in zip(responses, adb_commands.StreamingShell(command)):
+      self.assertEqual(expected, actual)
+      response_count = response_count + 1
+    self.assertEqual(len(responses), response_count)
+
   def testReboot(self):
     usb = self._ExpectCommand('reboot', '', '')
     adb_commands = self._Connect(usb)


### PR DESCRIPTION
This request implements adb_commands.StreamingShell, which yields each line of output instead of joining all the lines into one string.
