### PR TITLE
fix "checksum error" in adb_protocol.py

### DIFF
--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -226,7 +226,11 @@ class AdbMessage(object):
             cmd, (timeout_ms, total_timeout_ms))
 
     if data_length > 0:
-      data = usb.BulkRead(data_length, timeout_ms)
+      data = ''
+      while data_length > 0:
+        temp = usb.BulkRead(data_length, timeout_ms)
+        data = data + temp
+        data_length = data_length - len(temp)
       actual_checksum = cls.CalculateChecksum(data)
       if actual_checksum != data_checksum:
         raise InvalidChecksumError(


### PR DESCRIPTION
This fixes a problem where python-adb would report "checksum error" when receiving large amounts of data from the device.