### PR TITLE
Fixed cli dropping rest of args?

### DIFF
--- a/adb/common_cli.py
+++ b/adb/common_cli.py
@@ -128,7 +128,7 @@ def StartCli(argv, device_callback, kwarg_callback=None, list_callback=None,
   method = getattr(dev, method_name)
   argspec = inspect.getargspec(method)
   num_args = len(argspec.args) - 1  # self is the first one.
-  num_args -= len(argspec.defaults or [])
+  #num_args -= len(argspec.defaults or [])
   # Handle putting the remaining command line args into the last normal arg.
   argv.pop(0)
 


### PR DESCRIPTION
For example:
> python adb_debug.py pull src dest

dest was getting dropped and command always failed. Not sure if it's the correct way to fix it, but it worked for me.