### PR TITLE
Split off M2CryptoSigner into its own file.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,4 +2,5 @@ Fahrzin Hemmati <fahhem@gmail.com>
 Alex Lusco <alusco@google.com>
 Simon Ye <sye737+github@gmail.com>
 Jamey Hicks <jamey.hicks@gmail.com>
+Marc-Antoine Ruel <maruel@chromium.org>
 Max Borghino <fmborghino@gmail.com>

--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -26,8 +26,6 @@ import cStringIO
 import os
 import socket
 
-from M2Crypto import RSA
-
 import adb_protocol
 import common
 import filesync_protocol
@@ -40,20 +38,12 @@ PROTOCOL = 0x01
 DeviceIsAvailable = common.InterfaceMatcher(CLASS, SUBCLASS, PROTOCOL)
 
 
-class M2CryptoSigner(adb_protocol.AuthSigner):
-  """AuthSigner using M2Crypto."""
-
-  def __init__(self, rsa_key_path):
-    with open(rsa_key_path + '.pub') as rsa_pub_file:
-      self.public_key = rsa_pub_file.read()
-
-    self.rsa_key = RSA.load_key(rsa_key_path)
-
-  def Sign(self, data):
-    return self.rsa_key.sign(data, 'sha1')
-
-  def GetPublicKey(self):
-    return self.public_key
+try:
+  # Imported locally to keep compatibility with previous code.
+  from sign_m2crypto import M2CryptoSigner
+except ImportError:
+  # Ignore this error when M2Crypto is not installed, there are other options.
+  pass
 
 
 class AdbCommands(object):

--- a/adb/adb_debug.py
+++ b/adb/adb_debug.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +24,7 @@ import gflags
 
 import adb_commands
 import common_cli
+import sign_m2crypto
 
 gflags.ADOPT_module_key_flags(common_cli)
 
@@ -37,7 +39,7 @@ FLAGS = gflags.FLAGS
 def GetRSAKwargs():
   if FLAGS.rsa_key_path:
     return {
-        'rsa_keys': [adb_commands.M2CryptoSigner(os.path.expanduser(path))
+        'rsa_keys': [sign_m2crypto.M2CryptoSigner(os.path.expanduser(path))
                      for path in FLAGS.rsa_key_path],
         'auth_timeout_ms': int(FLAGS.auth_timeout_s * 1000.0),
     }

--- a/adb/sign_m2crypto.py
+++ b/adb/sign_m2crypto.py
@@ -1,0 +1,34 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from M2Crypto import RSA
+
+from adb import adb_protocol
+
+
+class M2CryptoSigner(adb_protocol.AuthSigner):
+  """AuthSigner using M2Crypto."""
+
+  def __init__(self, rsa_key_path):
+    with open(rsa_key_path + '.pub') as rsa_pub_file:
+      self.public_key = rsa_pub_file.read()
+
+    self.rsa_key = RSA.load_key(rsa_key_path)
+
+  def Sign(self, data):
+    return self.rsa_key.sign(data, 'sha1')
+
+  def GetPublicKey(self):
+    return self.public_key
+

--- a/adb/sign_pythonrsa.py
+++ b/adb/sign_pythonrsa.py
@@ -1,0 +1,64 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rsa
+
+from pyasn1.codec.der import decoder
+from pyasn1.type import univ
+from rsa import pkcs1
+
+
+# python-rsa lib hashes all messages it signs. ADB does it already, we just
+# need to slap a signature on top of already hashed message. Introduce "fake"
+# hashing algo for this.
+class _Accum(object):
+  def __init__(self):
+    self._buf = ''
+  def update(self, msg):
+    self._buf += msg
+  def digest(self):
+    return self._buf
+pkcs1.HASH_METHODS['SHA-1-PREHASHED'] = _Accum
+pkcs1.HASH_ASN1['SHA-1-PREHASHED'] = pkcs1.HASH_ASN1['SHA-1']
+
+
+def _load_rsa_private_key(pem):
+  """PEM encoded PKCS#8 private key -> rsa.PrivateKey."""
+  # ADB uses private RSA keys in pkcs#8 format. 'rsa' library doesn't support
+  # them natively. Do some ASN unwrapping to extract naked RSA key
+  # (in der-encoded form). See https://www.ietf.org/rfc/rfc2313.txt.
+  # Also http://superuser.com/a/606266.
+  try:
+    der = rsa.pem.load_pem(pem, 'PRIVATE KEY')
+    keyinfo, _ = decoder.decode(der)
+    if keyinfo[1][0] != univ.ObjectIdentifier(
+        '1.2.840.113549.1.1.1'):  # pragma: no cover
+      raise ValueError('Not a DER-encoded OpenSSL private RSA key')
+    private_key_der = keyinfo[2].asOctets()
+  except IndexError:  # pragma: no cover
+    raise ValueError('Not a DER-encoded OpenSSL private RSA key')
+  return rsa.PrivateKey.load_pkcs1(private_key_der, format='DER')
+
+
+class PythonRSASigner(object):
+  """Implements adb_protocol.AuthSigner using http://stuvel.eu/rsa."""
+  def __init__(self, pub, priv):
+    self.priv_key = _load_rsa_private_key(priv)
+    self.pub_key = pub
+
+  def Sign(self, data):
+    return rsa.sign(data, self.priv_key, 'SHA-1-PREHASHED')
+
+  def GetPublicKey(self):
+    return self.pub_key


### PR DESCRIPTION
Do not throw an ImportError if M2Crypto is not installed, there are
alternatives. Add support for python-rsa based implementation.

In particular, import M2CryptoSigner into adb_commands to keep backward compatibility.