### PR TITLE
Make adb_debug.py able to use python-rsa if M2Crypto is unavailable.

### DIFF
--- a/adb/adb_debug.py
+++ b/adb/adb_debug.py
@@ -24,7 +24,16 @@ import gflags
 
 import adb_commands
 import common_cli
-import sign_m2crypto
+
+try:
+  import sign_m2crypto
+except ImportError:
+  sign_m2crypto = None
+try:
+  import sign_pythonrsa
+except ImportError:
+  sign_pythonrsa = None
+
 
 gflags.ADOPT_module_key_flags(common_cli)
 
@@ -38,8 +47,14 @@ FLAGS = gflags.FLAGS
 
 def GetRSAKwargs():
   if FLAGS.rsa_key_path:
+    if not sign_m2crypto and not sign_pythonrsa:
+      print >> sys.stderr, 'Please install either M2Crypto or python-rsa'
+      sys.exit(1)
+    signer = (
+        sign_m2crypto.M2CryptoSigner if sign_m2crypto
+        else sign_pythonrsa.PythonRSASigner)
     return {
-        'rsa_keys': [sign_m2crypto.M2CryptoSigner(os.path.expanduser(path))
+        'rsa_keys': [signer(os.path.expanduser(path))
                      for path in FLAGS.rsa_key_path],
         'auth_timeout_ms': int(FLAGS.auth_timeout_s * 1000.0),
     }

--- a/adb/fastboot_debug.py
+++ b/adb/fastboot_debug.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/adb/sign_pythonrsa.py
+++ b/adb/sign_pythonrsa.py
@@ -53,7 +53,12 @@ def _load_rsa_private_key(pem):
 
 class PythonRSASigner(object):
   """Implements adb_protocol.AuthSigner using http://stuvel.eu/rsa."""
-  def __init__(self, pub, priv):
+  def __init__(self, rsa_key_path=None, pub=None, priv=None):
+    if rsa_key_path:
+      with open(rsa_key_path + '.pub') as f:
+        pub = f.read()
+      with open(rsa_key_path) as f:
+        priv = f.read()
     self.priv_key = _load_rsa_private_key(priv)
     self.pub_key = pub
 


### PR DESCRIPTION
python-rsa is installed by default on Ubuntu.

Make fastboot_debug.py a standalone executable.