### PR TITLE
Flags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ Cons:
 
 Dependencies:
   * libusb1 (1.0.16+)
-  * python-gflags (2.0+)
   * python-libusb1 (1.2.0+)
   * python-progressbar (for fastboot_debug, 2.3+)
-  * python-m2crypto (0.21.1+)
-
+  * One of:
+    * python-m2crypto (0.21.1+)
+    * python-rsa (3.2+)

--- a/adb/fastboot_debug.py
+++ b/adb/fastboot_debug.py
@@ -12,34 +12,94 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Fastboot debugging binary.
+
+"""Fastboot in python.
 
 Call it similar to how you call android's fastboot. Call it similar to how you
 call android's fastboot, but this only accepts usb paths and no serials.
 """
+
+import argparse
+import inspect
+import logging
 import sys
 
-import gflags
 import progressbar
 
 import common_cli
 import fastboot
 
-gflags.ADOPT_module_key_flags(common_cli)
 
-FLAGS = gflags.FLAGS
+def Devices(args):
+  """Lists the available devices.
+
+  List of devices attached
+  015DB7591102001A        device
+  """
+  for device in fastboot.FastbootCommands.Devices():
+    print('%s\tdevice' % device.serial_number)
+  return 0
 
 
-def KwargHandler(kwargs, argspec):
+def _InfoCb(message):
+  # Use an unbuffered version of stdout.
+  if not message.message:
+    return
+  sys.stdout.write('%s: %s\n' % (message.header, message.message))
+  sys.stdout.flush()
 
+
+def main():
+  common = common_cli.GetCommonArguments()
+  device = common_cli.GetDeviceArguments()
+  device.add_argument(
+      '--chunk_kb', type=int, default=1024, metavar='1024',
+      help='Size of packets to write in Kb. For older devices, it may be '
+           'required to use 4.')
+  parents = [common, device]
+
+  parser = argparse.ArgumentParser(
+      description=sys.modules[__name__].__doc__, parents=[common])
+  subparsers = parser.add_subparsers(title='Commands', dest='command_name')
+
+  subparser = subparsers.add_parser(
+      name='help', help='Prints the commands available')
+  subparser = subparsers.add_parser(
+      name='devices', help='Lists the available devices', parents=[common])
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Continue)
+
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Download,
+      {'source_file': 'Filename on the host to push'})
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Erase)
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Flash)
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Getvar)
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Oem)
+  common_cli.MakeSubparser(
+      subparsers, parents, fastboot.FastbootCommands.Reboot)
+
+  if len(sys.argv) == 1:
+    parser.print_help()
+    return 2
+
+  args = parser.parse_args()
+  if args.verbose:
+    logging.basicConfig(level=logging.DEBUG)
+  if args.command_name == 'devices':
+    return Devices(args)
+  if args.command_name == 'help':
+    parser.print_help()
+    return 0
+
+  kwargs = {}
+  argspec = inspect.getargspec(args.method)
   if 'info_cb' in argspec.args:
-    # Use an unbuffered version of stdout.
-    def InfoCb(message):
-      if not message.message:
-        return
-      sys.stdout.write('%s: %s\n' % (message.header, message.message))
-      sys.stdout.flush()
-    kwargs['info_cb'] = InfoCb
+    kwargs['info_cb'] = _InfoCb
   if 'progress_callback' in argspec.args:
     bar = progressbar.ProgessBar(
         widgets=[progressbar.Bar(), progressbar.Percentage()])
@@ -50,13 +110,10 @@ def KwargHandler(kwargs, argspec):
         bar.finish()
     kwargs['progress_callback'] = SetProgress
 
-
-def main(argv):
-  common_cli.StartCli(
-      argv, fastboot.FastbootCommands.ConnectDevice,
-      list_callback=fastboot.FastbootCommands.Devices,
-      kwarg_callback=KwargHandler)
+  return common_cli.StartCli(
+      args, fastboot.FastbootCommands.ConnectDevice, chunk_kb=args.chunk_kb,
+      extra=kwargs)
 
 
 if __name__ == '__main__':
-  main(FLAGS(sys.argv))
+  sys.exit(main())

--- a/adb_test.py
+++ b/adb_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/fastboot_test.py
+++ b/fastboot_test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,7 +116,7 @@ class FastbootTest(unittest.TestCase):
     progresses = []
 
     pieces = []
-    chunk_size = FLAGS.fastboot_write_chunk_size_kb * 1024
+    chunk_size = fastboot.FastbootProtocol(None).chunk_kb * 1024
     while raw:
       pieces.append(raw[:chunk_size])
       raw = raw[chunk_size:]

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ Android project's ADB.
 
     keywords = ['android', 'adb', 'fastboot'],
 
-    install_requires = ['python-gflags>=2.0', 'libusb1>=1.0.16', 'M2Crypto>=0.21.1'],
+    install_requires = ['libusb1>=1.0.16', 'M2Crypto>=0.21.1'],
 
     extra_requires = {
         'fastboot': 'progressbar>=2.3'


### PR DESCRIPTION
If you want, you can merge this one instead of https://github.com/google/python-adb/pull/16, as this merge request includes both.

Please try it locally first. I tried almost all commands on adb_debug.py and a few commands on fastboot_debug.py; getvar all and continue, as I didn't want to flash the device I was playing it. At least I confirmed I can access the device via --port_path in fastboot_debug.py.

This PR will remove the conflict in luci/python-adb about stripping gflags; this will ease the upstreaming process.

I made "./adb_debug.py list /path" output in a nice way as a bonus. I removed 'stat' since it was not very user-friendly.

The subparsers are still a bit too clever to my taste but if I hadn't done that, the code length would have exploded. At least the proposed design makes the help pages much more pleasant to read.