### PR TITLE
Add make_tools.py to generate adb.zip and fastboot.zip.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+/adb.zip
+/fastboot.zip

--- a/README.md
+++ b/README.md
@@ -6,34 +6,52 @@ python-adb
 This repository contains a pure-python implementation of the ADB and Fastboot
 protocols, using libusb1 for USB communications.
 
-This is a complete replacement and rearchitecture of the Android project's ADB
-and fastboot code available at
-https://github.com/android/platform_system_core/tree/master/adb
+This is a complete replacement and rearchitecture of the Android project's [ADB
+and fastboot code](https://github.com/android/platform_system_core/tree/master/adb)
 
 This code is mainly targeted to users that need to communicate with Android
 devices in an automated fashion, such as in automated testing. It does not have
 a daemon between the client and the device, and therefore does not support
 multiple simultaneous commands to the same device. It does support any number of
-devices and never communicates with a device that it wasn't intended to, unlike
-the Android project's ADB.
+devices and _never_ communicates with a device that it wasn't intended to,
+unlike the Android project's ADB.
 
-Pros:
+
+### Using as standalone tool
+
+Running `./make_tools.py` creates two files: `adb.zip` and `fastboot.zip`. They
+can be run similar to native `adb` and `fastboot` via the python interpreter:
+
+    python adb.zip devices
+    python adb.zip shell ls /sdcard
+
+
+### Pros
+
   * Simpler code due to use of libusb1 and Python.
   * API can be used by other Python code easily.
   * Errors are propagated with tracebacks, helping debug connectivity issues.
+  * No daemon outliving the command.
+  * Can be packaged as standalone zips that can be run independent of the CPU
+    architecture (e.g. x86 vs ARM).
 
-Cons:
+
+### Cons
+
   * Technically slower due to Python, mitigated by no daemon.
   * Only one command per device at a time.
   * More dependencies than Android's ADB.
 
-Dependencies:
+
+### Dependencies
+
   * libusb1 (1.0.16+)
   * python-libusb1 (1.2.0+)
-  * python-progressbar (for fastboot_debug, 2.3+)
-  * One of:
+  * `adb.zip`: one of:
     * python-m2crypto (0.21.1+)
     * python-rsa (3.2+)
+  * `fastboot.zip` (optional):
+    * python-progressbar (2.3+)
 
 [coverage_img]: https://coveralls.io/repos/github/google/python-adb/badge.svg?branch=master
 [coverage_link]: https://coveralls.io/github/google/python-adb?branch=master

--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -26,9 +26,9 @@ import cStringIO
 import os
 import socket
 
-import adb_protocol
-import common
-import filesync_protocol
+from adb import adb_protocol
+from adb import common
+from adb import filesync_protocol
 
 # From adb.h
 CLASS = 0xFF
@@ -40,7 +40,7 @@ DeviceIsAvailable = common.InterfaceMatcher(CLASS, SUBCLASS, PROTOCOL)
 
 try:
   # Imported locally to keep compatibility with previous code.
-  from sign_m2crypto import M2CryptoSigner
+  from adb.sign_m2crypto import M2CryptoSigner
 except ImportError:
   # Ignore this error when M2Crypto is not installed, there are other options.
   pass

--- a/adb/adb_debug.py
+++ b/adb/adb_debug.py
@@ -23,15 +23,15 @@ import stat
 import sys
 import time
 
-import adb_commands
-import common_cli
+from adb import adb_commands
+from adb import common_cli
 
 try:
-  import sign_m2crypto
+  from adb import sign_m2crypto
   rsa_signer = sign_m2crypto.M2CryptoSigner
 except ImportError:
   try:
-    import sign_pythonrsa
+    from adb import sign_pythonrsa
     rsa_signer = sign_pythonrsa.PythonRSASigner.FromRSAKeyPath
   except ImportError:
     rsa_signer = None

--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -20,7 +20,7 @@ host side.
 import struct
 import time
 
-import usb_exceptions
+from adb import usb_exceptions
 
 
 # Maximum amount of data in an ADB packet.

--- a/adb/common.py
+++ b/adb/common.py
@@ -23,7 +23,7 @@ import weakref
 import libusb1
 import usb1
 
-import usb_exceptions
+from adb import usb_exceptions
 
 DEFAULT_TIMEOUT_MS = 1000
 

--- a/adb/common_cli.py
+++ b/adb/common_cli.py
@@ -28,7 +28,7 @@ import sys
 import textwrap
 import types
 
-import usb_exceptions
+from adb import usb_exceptions
 
 
 class _PortPathAction(argparse.Action):

--- a/adb/fastboot.py
+++ b/adb/fastboot.py
@@ -21,8 +21,8 @@ import logging
 import os
 import struct
 
-import common
-import usb_exceptions
+from adb import common
+from adb import usb_exceptions
 
 
 _LOG = logging.getLogger('fastboot')

--- a/adb/fastboot_debug.py
+++ b/adb/fastboot_debug.py
@@ -24,10 +24,14 @@ import inspect
 import logging
 import sys
 
-import progressbar
+from adb import common_cli
+from adb import fastboot
 
-import common_cli
-import fastboot
+try:
+  import progressbar
+except ImportError:
+  # progressbar is optional.
+  progressbar = None
 
 
 def Devices(args):
@@ -100,7 +104,7 @@ def main():
   argspec = inspect.getargspec(args.method)
   if 'info_cb' in argspec.args:
     kwargs['info_cb'] = _InfoCb
-  if 'progress_callback' in argspec.args:
+  if 'progress_callback' in argspec.args and progressbar:
     bar = progressbar.ProgessBar(
         widgets=[progressbar.Bar(), progressbar.Percentage()])
     bar.start()

--- a/adb/filesync_protocol.py
+++ b/adb/filesync_protocol.py
@@ -24,8 +24,8 @@ import time
 
 import libusb1
 
-import adb_protocol
-import usb_exceptions
+from adb import adb_protocol
+from adb import usb_exceptions
 
 # Default mode for pushed files.
 DEFAULT_PUSH_MODE = stat.S_IFREG | stat.S_IRWXU | stat.S_IRWXG

--- a/make_tools.py
+++ b/make_tools.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Creates adb.zip and fastboot.zip as standalone executables.
+
+These files can be executed via:
+  python adb.zip devices
+
+The same way one would have run:
+  python adb_debug.py devices
+
+The zips can be transferred to other computers (and other CPU architectures) for
+CPU and OS agnostic execution.
+"""
+
+import os
+import sys
+import zipfile
+
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def main():
+  os.chdir(THIS_DIR)
+  with zipfile.ZipFile('adb.zip', 'w', zipfile.ZIP_DEFLATED) as z:
+    z.write('adb/__init__.py')
+    z.write('adb/adb_commands.py')
+    z.write('adb/adb_debug.py', '__main__.py')
+    z.write('adb/adb_protocol.py')
+    z.write('adb/common.py')
+    z.write('adb/common_cli.py')
+    z.write('adb/filesync_protocol.py')
+    z.write('adb/sign_m2crypto.py')
+    z.write('adb/sign_pythonrsa.py')
+    z.write('adb/usb_exceptions.py')
+  with zipfile.ZipFile('fastboot.zip', 'w', zipfile.ZIP_DEFLATED) as z:
+    z.write('adb/__init__.py')
+    z.write('adb/common.py')
+    z.write('adb/common_cli.py')
+    z.write('adb/fastboot.py')
+    z.write('adb/fastboot_debug.py', '__main__.py')
+    z.write('adb/usb_exceptions.py')
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
Change imports to always be relative to the package, e.g. "from adb import ..."

make_tools.py creates standalone, easy to distribute executables meant to be
used in a continuous integration system via various CPU architecture where
having interpreted code is valuable.

Make progressbar optional so both adb.zip and fastboot.zip do not have any hard
dependency except python-libusb.