### PR TITLE
We shouldn't use xrange in Python 3.x, range is the same as xrange

### DIFF
--- a/adb/common_cli.py
+++ b/adb/common_cli.py
@@ -98,7 +98,7 @@ def MakeSubparser(subparsers, parents, method, arguments=None):
   # arguments that default to '' but excludes arguments that default to None.
   offset = len(argspec.args) - len(argspec.defaults or []) - 1
   positional = []
-  for i in xrange(1, len(argspec.args)):
+  for i in range(1, len(argspec.args)):
     if i > offset and argspec.defaults[i-offset-1] is None:
       break
     positional.append(argspec.args[i])


### PR DESCRIPTION
Hi,

This is my first pull request to Google so please be gentle... :) in Python 3.x xrange has been deprecated and removed from more recent versions. range is the same as xrange from Python 2.x

1: https://docs.python.org/3/whatsnew/3.0.html

2: https://stackoverflow.com/a/95100