### PR TITLE
Fix double CLSE bug

### DIFF
--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -351,8 +351,12 @@ class AdbMessage(object):
       raise InvalidResponseError(
           'Expected the local_id to be %s, got %s' % (local_id, their_local_id))
     if cmd == b'CLSE':
+      # Some devices seem to be sending CLSE once more after a request, this *should* handle it
+      cmd, remote_id, their_local_id, _ = cls.Read(usb, [b'CLSE', b'OKAY'],
+                                                   timeout_ms=timeout_ms)
       # Device doesn't support this service.
-      return None
+      if cmd == b'CLSE':
+        return None
     if cmd != b'OKAY':
       raise InvalidCommandError('Expected a ready response, got %s' % cmd,
                                 cmd, (remote_id, their_local_id))


### PR DESCRIPTION
This fixes #39 and fixes #59.

I'm not sure if this is the best fix for the issue: if CLSE is received, we attempt to re-read and see if it's CLSE again, in which case, the original behaviour is done.

I've been testing this for a few days on a Galaxy S7 & S8 (both Qualcomm), a US LG G6, all running Android 7.x, and Genymotion (6.0 and 7.0), and it seems to work fine.