### PR TITLE
Fixed console scripts entry points naming clash with android-adb-tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,8 @@ Android project's ADB.
     ],
     entry_points={
         "console_scripts": [
-            "adb = adb.adb_debug:main",
-            "fastboot = adb.fastboot_debug:main",
+            "pyadb = adb.adb_debug:main",
+            "pyfastboot = adb.fastboot_debug:main",
         ],
     }
 


### PR DESCRIPTION
Changed console scripts entry points to use names that do not conflict with android's existing tool names

Running setup.py develop/install will create binaries in your Python env's bin/ folder which is likely in the user's path. If the user has the normal 'android-adb-tools' installed or simply the android platform-tools folder in their path AND the Python env this package is installed in, this package takes precedent when 'adb' is run. This might break other programs on the system that expect the regular ADB to run.

Fix: Changed the entry points to be 'pyadb' and 'pyfastboot' so the user still has the choice to run normal 'adb' and 'fastboot'. Feel free to change these entry point names to something else if you do not like the prefixes I've chosen.
