### PR TITLE
Fixed TypeError in TcpHandle and sign_pythonrsa

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,4 +7,4 @@ Max Borghino <fmborghino@gmail.com>
 Mohammad Abu-Garbeyyeh <github@mohammadag.com>
 Josip Delic <delijati@gmail.com>
 Greg E. <greateggsgreg@gmail.com>
-
+Yongguang Lin <linsoft@yeah.net>

--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -128,7 +128,7 @@ class AdbCommands(object):
     # If there isnt a handle override (used by tests), build one here
     if 'handle' in kwargs:
       self._handle = kwargs.pop('handle')
-    elif serial and b':' in serial:
+    elif serial and ':' in serial:
       self._handle = common.TcpHandle(serial, timeout_ms=default_timeout_ms)
     else:
       self._handle = common.UsbHandle.FindAndOpen(

--- a/adb/common.py
+++ b/adb/common.py
@@ -295,8 +295,8 @@ class TcpHandle(object):
 
     Host may be an IP address or a host name.
     """
-    if b':' in serial:
-      (host, port) = serial.split(b':')
+    if ':' in serial:
+      (host, port) = serial.split(':')
     else:
       host = serial
       port = 5555

--- a/adb/sign_pythonrsa.py
+++ b/adb/sign_pythonrsa.py
@@ -24,7 +24,7 @@ from rsa import pkcs1
 # hashing algo for this.
 class _Accum(object):
   def __init__(self):
-    self._buf = ''
+    self._buf = b''
   def update(self, msg):
     self._buf += msg
   def digest(self):


### PR DESCRIPTION
See #86 

In Python3, using `str` as the type of _buf causes `TypeError: Can't convert 'bytes' object to str implicitly` in the newest commit 0b15f4fc69c8b9ed87a82964fd6d2eed8d637f21 with python-rsa.
```python
  File ".\adb.zip\__main__.py", line 210, in <module>
  File ".\adb.zip\__main__.py", line 206, in main
  File ".\adb.zip\adb\common_cli.py", line 149, in StartCli
  File ".\adb.zip\adb\adb_commands.py", line 138, in ConnectDevice
  File ".\adb.zip\adb\adb_commands.py", line 169, in _Connect
  File ".\adb.zip\adb\adb_protocol.py", line 320, in Connect
  File ".\adb.zip\adb\sign_pythonrsa.py", line 69, in Sign
  File "E:\Python\Python3\lib\site-packages\rsa\pkcs1.py", line 272, in sign
    hash = _hash(message, hash)
  File "E:\Python\Python3\lib\site-packages\rsa\pkcs1.py", line 346, in _hash
    hasher.update(message)
  File ".\adb.zip\adb\sign_pythonrsa.py", line 29, in update
TypeError: Can't convert 'bytes' object to str implicitly
```

And it can be fixed below:
```python
   # hashing algo for this.
   class _Accum(object):
     def __init__(self):
 -     self._buf = ''
 +     self._buf = b''
     def update(self, msg):
       self._buf += msg
     def digest(self):
       return self._buf
```

And thanks to @Myonium, the TypeError in TcpHandle can also be resolved.

@fahhem I don't know why this PR cannot be accepted. If you guys don't want to merge this branch, just close it.