### PR TITLE
some err : argparse's Inheriting parents 

### DIFF
--- a/adb/adb_debug.py
+++ b/adb/adb_debug.py
@@ -136,10 +136,9 @@ def main():
         help='Seconds to wait for the dialog to be accepted when using '
              'authenticated ADB.')
     device = common_cli.GetDeviceArguments()
-    parents = [common, device]
-
+    parents = [ device,common]
     parser = argparse.ArgumentParser(
-        description=sys.modules[__name__].__doc__, parents=[common])
+        description=sys.modules[__name__].__doc__, parents=parents)
     subparsers = parser.add_subparsers(title='Commands', dest='command_name')
 
     subparser = subparsers.add_parser(

--- a/adb/adb_debug.py
+++ b/adb/adb_debug.py
@@ -136,7 +136,7 @@ def main():
         help='Seconds to wait for the dialog to be accepted when using '
              'authenticated ADB.')
     device = common_cli.GetDeviceArguments()
-    parents = [ device,common]
+    parents = [ common,device]
     parser = argparse.ArgumentParser(
         description=sys.modules[__name__].__doc__, parents=parents)
     subparsers = parser.add_subparsers(title='Commands', dest='command_name')


### PR DESCRIPTION
the error  make  `common_cli.py` is method `GetDeviceArguments()` ‘s  return   object  not be  inherited 

in the command line interface :
'''
 --port_path PORT_PATH
                        USB port path integers (eg 1,2 or 2,1,1)
  -s SERIAL, --serial SERIAL
                        Device serial to look for (host:port or USB serial)

'''
will not show