### PR TITLE
Fix RSA keyfile open mode (rb) for python3 (#141)

### DIFF
--- a/adb/sign_m2crypto.py
+++ b/adb/sign_m2crypto.py
@@ -21,7 +21,7 @@ class M2CryptoSigner(adb_protocol.AuthSigner):
     """AuthSigner using M2Crypto."""
 
     def __init__(self, rsa_key_path):
-        with open(rsa_key_path + '.pub') as rsa_pub_file:
+        with open(rsa_key_path + '.pub', 'rb') as rsa_pub_file:
             self.public_key = rsa_pub_file.read()
 
         self.rsa_key = RSA.load_key(rsa_key_path)

--- a/adb/sign_pythonrsa.py
+++ b/adb/sign_pythonrsa.py
@@ -60,9 +60,9 @@ class PythonRSASigner(object):
 
     @classmethod
     def FromRSAKeyPath(cls, rsa_key_path):
-        with open(rsa_key_path + '.pub') as f:
+        with open(rsa_key_path + '.pub', 'rb') as f:
             pub = f.read()
-        with open(rsa_key_path) as f:
+        with open(rsa_key_path, 'rb') as f:
             priv = f.read()
         return cls(pub, priv)
 


### PR DESCRIPTION
Proposed fix.

 I only really tested it with the `m2crypto` signer, but I assumed it would be the same for `sign_pythonrsa.py`