### PR TITLE
Remove M2Crypto version restriction from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 
 # Figure out if the system already has a supported Crypto library
-rsa_signer_library = 'M2Crypto>=0.21.1,<=0.26.4'
+rsa_signer_library = 'M2Crypto'
 try:
   import rsa
 


### PR DESCRIPTION
Fix #70?

Would this work? I don't know of the original reason for the version restrictions, but it seems to work with latest (0.31.0).