### PR TITLE
Builtin 'file' was removed in Python 3

### DIFF
--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -31,6 +31,11 @@ from adb import adb_protocol
 from adb import common
 from adb import filesync_protocol
 
+try:
+    file           # Python 2
+except NameError:  # Python 3
+    file = io.BaseIO
+
 # From adb.h
 CLASS = 0xFF
 SUBCLASS = 0x42

--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -34,7 +34,7 @@ from adb import filesync_protocol
 try:
     file           # Python 2
 except NameError:  # Python 3
-    file = io.BaseIO
+    file = io.IOBase
 
 # From adb.h
 CLASS = 0xFF

--- a/adb/filesync_protocol.py
+++ b/adb/filesync_protocol.py
@@ -28,6 +28,12 @@ import libusb1
 from adb import adb_protocol
 from adb import usb_exceptions
 
+try:
+    file           # Python 2
+except NameError:  # Python 3
+    import io
+    file = io.BaseIO
+
 # Default mode for pushed files.
 DEFAULT_PUSH_MODE = stat.S_IFREG | stat.S_IRWXU | stat.S_IRWXG
 # Maximum size of a filesync DATA packet.

--- a/adb/filesync_protocol.py
+++ b/adb/filesync_protocol.py
@@ -32,7 +32,7 @@ try:
     file           # Python 2
 except NameError:  # Python 3
     import io
-    file = io.BaseIO
+    file = io.IOBase
 
 # Default mode for pushed files.
 DEFAULT_PUSH_MODE = stat.S_IFREG | stat.S_IRWXU | stat.S_IRWXG


### PR DESCRIPTION
An alternative solution to #140 for fixing the issue raised in #126