### PR TITLE
Fastboot Boot support, Android 9 fix, Fixed PycryptodomeAuthSigner's sign method

### DIFF
--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -256,9 +256,9 @@ class AdbCommands(object):
           device_filename: Destination on the device to write to.
           mtime: Optional, modification time to set on the file.
           timeout_ms: Expected timeout for any part of the push.
-          st_mode: stat mode for filename
           progress_callback: callback method that accepts filename, bytes_written and total_bytes,
                              total_bytes will be -1 for file-like objects
+          st_mode: stat mode for filename
         """
 
         if isinstance(source_file, str):

--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -19,6 +19,7 @@ host side.
 
 import struct
 import time
+import re
 from io import BytesIO
 from adb import usb_exceptions
 
@@ -551,8 +552,11 @@ class AdbMessage(object):
                     stdout = stdout.split(b'\r\r\n')[1]
 
             # Strip delim if requested
-            # TODO: Handling stripping partial delims here - not a deal breaker the way we're handling it now
             if delim and strip_delim:
+                prefix_exp = re.compile(r'(?P<prefix>\d{1,3}\|)'+delim.decode('utf-8', errors='ignore'))
+                match = re.match(prefix_exp, stdout.decode('utf-8', errors='ignore'))
+                if match:
+                    stdout = stdout.replace(str(match.group('prefix') + delim).encode('utf-8'), b'')
                 stdout = stdout.replace(delim, b'')
 
             stdout = stdout.rstrip()

--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -324,7 +324,7 @@ class AdbMessage(object):
                         'Unknown AUTH response: %s %s %s' % (arg0, arg1, banner))
 
                 # Do not mangle the banner property here by converting it to a string
-                signed_token = rsa_key.Sign(banner)
+                signed_token = rsa_key.Sign(banner) + b'\0'
                 msg = cls(
                     command=b'AUTH', arg0=AUTH_SIGNATURE, arg1=0, data=signed_token)
                 msg.Send(usb)

--- a/adb/common_cli.py
+++ b/adb/common_cli.py
@@ -27,6 +27,7 @@ import logging
 import re
 import sys
 import types
+import traceback
 
 from adb import usb_exceptions
 
@@ -158,7 +159,7 @@ def StartCli(args, adb_commands, extra=None, **device_kwargs):
     try:
         return _RunMethod(dev, args, extra or {})
     except Exception as e:  # pylint: disable=broad-except
-        sys.stdout.write(str(e))
+        sys.stdout.write(traceback.format_exc())
         return 1
     finally:
         dev.Close()

--- a/adb/fastboot.py
+++ b/adb/fastboot.py
@@ -124,7 +124,7 @@ class FastbootProtocol(object):
           FastbootInvalidResponse: Fastboot responded with an unknown packet type.
 
         Returns:
-          Tuple - OKAY packet's message, List of preceding Fastboot Messages
+          tuple (OKAY packet's message, List of preceding Fastboot Messages)
         """
         accepted_size, _msgs = self._AcceptResponses(
             b'DATA', info_cb, timeout_ms=timeout_ms)
@@ -152,7 +152,7 @@ class FastbootProtocol(object):
           FastbootInvalidResponse: Fastboot responded with an unknown packet type.
 
         Returns:
-          Tuple - OKAY packet's message, List of preceding Fastboot Messages
+          tuple (OKAY packet's message, List of preceding Fastboot Messages)
         """
 
         messages = []
@@ -413,11 +413,13 @@ class FastbootCommands(object):
         return self._SimpleCommand(b'reboot-bootloader', timeout_ms=timeout_ms)
 
     def Boot(self, source_file):
-        """
-        Fastboot boot image by sending image from local file system then issuing the boot command
+        """Fastboot boot image by sending image from local file system then issuing the boot command
 
-        :param source_file:
-        :return:
+        Args:
+            source_file: String file path to the image to send and boot
+
+        Returns:
+            None
         """
 
         if not os.path.exists(source_file):

--- a/adb/fastboot.py
+++ b/adb/fastboot.py
@@ -328,6 +328,9 @@ class FastbootCommands(object):
             with open(source_file_path, 'rb') as fh:
                 source_file = BytesIO(fh.read())
 
+        elif isinstance(source_file, StringIO):
+            source_file = BytesIO(source_file.read())
+
         if not source_len:
             source_len = len(source_file)
 

--- a/adb/fastboot.py
+++ b/adb/fastboot.py
@@ -328,11 +328,13 @@ class FastbootCommands(object):
             with open(source_file_path, 'rb') as fh:
                 source_file = BytesIO(fh.read())
 
-        elif isinstance(source_file, StringIO):
-            source_file = BytesIO(source_file.read())
-
         if not source_len:
-            source_len = len(source_file)
+            if isinstance(source_file, StringIO):
+                source_file.seek(0, os.SEEK_END)
+                source_len = source_file.tell()
+                source_file.seek(0)
+            else:
+                source_len = len(source_file)
 
         self._protocol.SendCommand(b'download', b'%08x' % source_len)
         return self._protocol.HandleDataSending(

--- a/adb/fastboot.py
+++ b/adb/fastboot.py
@@ -19,7 +19,7 @@ import io
 import logging
 import os
 import struct
-from io import BytesIO
+from io import BytesIO, StringIO
 
 from adb import common
 from adb import usb_exceptions
@@ -100,9 +100,9 @@ class FastbootProtocol(object):
           info_cb: Optional callback for text sent from the bootloader.
 
         Returns:
-          Tuple - OKAY packet's message, List of preceding Fastboot Messages
+          OKAY packet's message
         """
-        return self._AcceptResponses(b'OKAY', info_cb, timeout_ms=timeout_ms)
+        return self._AcceptResponses(b'OKAY', info_cb, timeout_ms=timeout_ms)[0]
 
     def HandleDataSending(self, source_file, source_len,
                           info_cb=DEFAULT_MESSAGE_CALLBACK,
@@ -336,7 +336,7 @@ class FastbootCommands(object):
 
         self._protocol.SendCommand(b'download', b'%08x' % source_len)
         return self._protocol.HandleDataSending(
-            source_file, source_len, info_cb, progress_callback=progress_callback)
+            source_file, source_len, info_cb, progress_callback=progress_callback)[0]
 
     def Flash(self, partition, timeout_ms=0, info_cb=DEFAULT_MESSAGE_CALLBACK):
         """Flashes the last downloaded file to the given partition.

--- a/adb/fastboot_debug.py
+++ b/adb/fastboot_debug.py
@@ -86,6 +86,9 @@ def main():
         subparsers, parents, fastboot.FastbootCommands.Oem)
     common_cli.MakeSubparser(
         subparsers, parents, fastboot.FastbootCommands.Reboot)
+    common_cli.MakeSubparser(
+        subparsers, parents, fastboot.FastbootCommands.Boot,
+        {'source_file': 'Image file on the host to push and boot'})
 
     if len(sys.argv) == 1:
         parser.print_help()

--- a/adb/sign_pycryptodome.py
+++ b/adb/sign_pycryptodome.py
@@ -1,8 +1,8 @@
 from adb import adb_protocol
 
-from Crypto.Hash import SHA256
 from Crypto.PublicKey import RSA
 from Crypto.Signature import pkcs1_15
+from Crypto.Util import number
 
 
 class PycryptodomeAuthSigner(adb_protocol.AuthSigner):
@@ -18,8 +18,48 @@ class PycryptodomeAuthSigner(adb_protocol.AuthSigner):
                 self.rsa_key = RSA.import_key(rsa_priv_file.read())
 
     def Sign(self, data):
-        h = SHA256.new(data)
-        return pkcs1_15.new(self.rsa_key).sign(h)
+        # Prepend precomputed ASN1 hash code for SHA1
+        data = b'\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14' + data
+        pkcs = pkcs1_15.new(self.rsa_key)
+
+        # See 8.2.1 in RFC3447
+        modBits = number.size(pkcs._key.n)
+        k = pkcs1_15.ceil_div(modBits,8) # Convert from bits to bytes
+
+        # Step 2a (OS2IP)
+        em_int = pkcs1_15.bytes_to_long(PycryptodomeAuthSigner._pad_for_signing(data, k))
+        # Step 2b (RSASP1)
+        m_int = pkcs._key._decrypt(em_int)
+        # Step 2c (I2OSP)
+        signature = pkcs1_15.long_to_bytes(m_int, k)
+
+        return signature
 
     def GetPublicKey(self):
         return self.public_key
+
+    @staticmethod
+    def _pad_for_signing(message, target_length):
+        """Pads the message for signing, returning the padded message.
+
+        The padding is always a repetition of FF bytes.
+
+        Function from python-rsa to replace _EMSA_PKCS1_V1_5_ENCODE's for our use case
+
+        :return: 00 01 PADDING 00 MESSAGE
+
+        """
+
+        max_msglength = target_length - 11
+        msglength = len(message)
+
+        if msglength > max_msglength:
+            raise OverflowError('%i bytes needed for message, but there is only'
+                                ' space for %i' % (msglength, max_msglength))
+
+        padding_length = target_length - msglength - 3
+
+        return b''.join([b'\x00\x01',
+                         padding_length * b'\xff',
+                         b'\x00',
+                         message])


### PR DESCRIPTION
Fixed implementation of PycryptodomeAuthSigner.sign() method to properly resign the provided token.  Also made minor fix to stripping delimiters from the InteractiveShell output, eliminating a TODO