### PR TITLE
Update sign_cryptography.py

### DIFF
--- a/adb/sign_cryptography.py
+++ b/adb/sign_cryptography.py
@@ -26,11 +26,20 @@ class CryptographySigner(adb_protocol.AuthSigner):
 
     def __init__(self, rsa_key_path):
         with open(rsa_key_path + '.pub') as rsa_pub_file:
-            self.public_key = rsa_pub_file.read()
+            rsa_data = rsa_pub_file.read()
+            if isinstance (rsa_data,str):
+                self.public_key = rsa_data
+            else:
+                self.public_key = rsa_data.encode('ascii')
 
         with open(rsa_key_path) as rsa_prv_file:
-            self.rsa_key = serialization.load_pem_private_key(
-                    rsa_prv_file.read(), None, default_backend())
+            rsa_data = rsa_prv_file.read()
+            if isinstance (rsa_data,str):
+                self.rsa_key = serialization.load_pem_private_key(
+                        rsa_data, None, default_backend())
+            else:
+                self.rsa_key = serialization.load_pem_private_key(
+                        rsa_data.encode('ascii'), None, default_backend())          
 
     def Sign(self, data):
         return self.rsa_key.sign(


### PR DESCRIPTION
fix python3 read() return is utf-8 to ascii