### PR TITLE
restore GetPublicKey interface mistakenly removed 

### DIFF
--- a/adb/sign_cryptography.py
+++ b/adb/sign_cryptography.py
@@ -35,3 +35,6 @@ class CryptographySigner(adb_protocol.AuthSigner):
     def Sign(self, data):
         return self.rsa_key.sign(
             data, padding.PKCS1v15(), utils.Prehashed(hashes.SHA1()))
+
+    def GetPublicKey(self):
+        return self.public_key


### PR DESCRIPTION
restore GetPublicKey interface mistakenly removed in 4b555e64d1e49d91ed851c59bb11b734b302f71d