### PR TITLE
Workaroud for UnicodeDecodeError

### DIFF
--- a/test/adb_test.py
+++ b/test/adb_test.py
@@ -180,7 +180,7 @@ class AdbTest(BaseAdbTest):
       dev.ConnectDevice(handle=usb, banner=BANNER)
 
       res = dev.Shell(command)
-      self.assertEqual('\u3042', res)
+      self.assertEqual(u'\u3042', res)
 
   def testBytesStreamingResponseShell(self):
       command = b'keepin it real big'
@@ -209,7 +209,7 @@ class AdbTest(BaseAdbTest):
       dev = adb_commands.AdbCommands()
       dev.ConnectDevice(handle=usb, banner=BANNER)
 
-      res = dev.NonStreamingLogcat('test\u3042')
+      res = dev.NonStreamingLogcat(u'test\u3042')
       self.assertEqual(u'\u3042', res)
 
   def testReboot(self):

--- a/test/adb_test.py
+++ b/test/adb_test.py
@@ -14,18 +14,18 @@
 # limitations under the License.
 """Tests for adb."""
 
-from io import BytesIO
 import struct
 import unittest
+from io import BytesIO
+from unittest import skip
+
+import common_stub
 from mock import mock
 
-
-from adb import common
 from adb import adb_commands
 from adb import adb_protocol
-from adb.usb_exceptions import TcpTimeoutException, DeviceNotFoundError
-import common_stub
-
+from adb import common
+from adb.usb_exceptions import TcpTimeoutException
 
 BANNER = b'blazetest'
 LOCAL_ID = 1
@@ -140,7 +140,7 @@ class AdbTest(BaseAdbTest):
 
   def testStreamingResponseShell(self):
     command = b'keepin it real big'
-    # expect multiple lines
+    # expect multiple bulks
 
     responses = ['other stuff, ', 'and some words.']
 
@@ -149,10 +149,68 @@ class AdbTest(BaseAdbTest):
     dev = adb_commands.AdbCommands()
     dev.ConnectDevice(handle=usb, banner=BANNER)
     response_count = 0
-    for (expected,actual) in zip(responses, dev.StreamingShell(command)):
+    for (expected, actual) in zip(responses, dev.StreamingShell(command)):
       self.assertEqual(expected, actual)
       response_count = response_count + 1
     self.assertEqual(len(responses), response_count)
+
+  @skip('Need fixing')
+  def testStreamingResponseShellWithMultiBytesSequences(self):
+      command = b'keepin it real big'
+      # expect multiple bulks
+
+      responses = [b'\xe2', b'\x81\x82']  # utf-8 encoded split Hiragana A (U+3042)
+
+      usb = self._ExpectCommand(b'shell', command, *responses)
+
+      dev = adb_commands.AdbCommands()
+      dev.ConnectDevice(handle=usb, banner=BANNER)
+
+      dev.StreamingShell(command)
+
+  def testShellWithMultiBytesSequences(self):
+      command = b'keepin it real big'
+      # expect multiple bulks
+
+      responses = [b'\xe3', b'\x81\x82']  # utf-8 encoded split Hiragana A (U+3042)
+
+      usb = self._ExpectCommand(b'shell', command, *responses)
+
+      dev = adb_commands.AdbCommands()
+      dev.ConnectDevice(handle=usb, banner=BANNER)
+
+      res = dev.Shell(command)
+      self.assertEqual('\u3042', res)
+
+  def testBytesStreamingResponseShell(self):
+      command = b'keepin it real big'
+      # expect multiple bulks
+
+      responses = [b'other stuff, ', b'and some words.']
+
+      usb = self._ExpectCommand(b'shell', command, *responses)
+
+      dev = adb_commands.AdbCommands()
+      dev.ConnectDevice(handle=usb, banner=BANNER)
+      response_count = 0
+      for (expected, actual) in zip(responses, dev.BytesStreamingShell(command)):
+          self.assertEqual(expected, actual)
+          response_count = response_count + 1
+      self.assertEqual(len(responses), response_count)
+
+  def testNonStreamingLogcatWithMultiBytesSequences(self):
+      command = b'logcat test\xe3\x81\x82'
+      # expect multiple bulks
+
+      responses = [b'\xe3', b'\x81\x82']  # utf-8 encoded split Hiragana A (U+3042)
+
+      usb = self._ExpectCommand(b'shell', command, *responses)
+
+      dev = adb_commands.AdbCommands()
+      dev.ConnectDevice(handle=usb, banner=BANNER)
+
+      res = dev.NonStreamingLogcat('test\u3042')
+      self.assertEqual(u'\u3042', res)
 
   def testReboot(self):
     usb = self._ExpectCommand(b'reboot', b'', b'')


### PR DESCRIPTION
# Why:

Fix a random UnicodeDecodeError, when using AdbCommands.Logcat.

## Steps to reproduce

* Add multi-bytes characters to log file
* Try to use AdbCommands.Logcat

## Expected result

Output result as unicode string (or str in python3)

## Actual result

UnicodeDecodeError is  **sometime** raised with the following message:

> ERROR: 'utf-8' codec can't decode byte 0xe3 in position 4095: unexpected end of data

The exception is raised from the method AdbMessage.StreamingCommand() from the module adb_protocol.py:

```python
    @classmethod
    def StreamingCommand(cls, usb, service, command='', timeout_ms=None):
        """
        ...
        """
        if not isinstance(command, bytes):
            command = command.encode('utf8')
        connection = cls.Open(
            usb, destination=b'%s:%s' % (service, command),
            timeout_ms=timeout_ms)
        for data in connection.ReadUntilClose():
            yield data.decode('utf-8')  # <---- HERE
```

## Investigation

When streaming output of command, a max length is provided to UsbHandle.BulkRead. This length is (if I understood correctly) given in bytes.

So the end of a bulk of bytes data can append at any given bytes.

But in utf-8, characters may be encoded on multiples bytes (ex: あ (U+3042) is encoded as 0xE3 0x81 0x82 in utf-8).

Since, the bulk may end at any given bytes, it is possible for a multi-byte sequence to be split between two bulks (ex: [b'...\xe3', b'\x81\x82...'] ).

But, decoding will fail if a multi-byte sequence is incomplete (try to run ``b'AAA\xe3'.decode('utf-8')`` in a python console).

# What:

This pull request contains...


* A test case with a ``@skip`` decorator to illustrate the problem. 

* New "Bytes" methods that implements a "workaround" (ie. using bytes and decode only when stream is complete)

* New tests to cover the new "Bytes" methods

There is probably a better solution, but this is what worked for me. And I hope that it will help to illustrate the problem with StreamingCommand.