### PR TITLE
Bugfix - sign_cryptography.CryptographySigner - keyfile opened as text (breaks on Python 3)

### DIFF
--- a/adb/sign_cryptography.py
+++ b/adb/sign_cryptography.py
@@ -25,10 +25,10 @@ class CryptographySigner(adb_protocol.AuthSigner):
     """AuthSigner using cryptography.io."""
 
     def __init__(self, rsa_key_path):
-        with open(rsa_key_path + '.pub') as rsa_pub_file:
+        with open(rsa_key_path + '.pub', 'rb') as rsa_pub_file:
             self.public_key = rsa_pub_file.read()
 
-        with open(rsa_key_path) as rsa_prv_file:
+        with open(rsa_key_path, 'rb') as rsa_prv_file:
             self.rsa_key = serialization.load_pem_private_key(
                     rsa_prv_file.read(), None, default_backend())
 


### PR DESCRIPTION
This should fix an issue caused by the `CryptographySigner` initializer method, 
which opens the RSA public/private key files for reading in "text mode" instead of "binary mode".

Python 2.x _does_ work with this, but on Python 3 this breaks pretty quickly.
