### PR TITLE
ADB over serial port support. serial=/dev/ttyS1,115200

### DIFF
--- a/adb/adb_commands.py
+++ b/adb/adb_commands.py
@@ -134,6 +134,8 @@ class AdbCommands(object):
 
             if serial and ':' in serial:
                 self._handle = common.TcpHandle(serial, timeout_ms=default_timeout_ms)
+            elif 'tty' in serial:
+                self._handle = common.SerialHandle(serial, timeout_ms=default_timeout_ms)
             else:
                 self._handle = common.UsbHandle.FindAndOpen(
                     DeviceIsAvailable, port_path=port_path, serial=serial,


### PR DESCRIPTION
Add support to connect to ADB over serial port.
Adds pySerial as a dependency.

Usage is as simple as

```
device.ConnectDevice(port_path=None, serial="/dev/ttyS11,115200")
```
In the case the baudrate is not specified, default is 115200.
`tty` is the keyword that triggers the `SerialHandler` instead of the Usb or Tcp ones.