### PR TITLE
docs: fix simple typo, somthing -> something

### DIFF
--- a/adb/adb_protocol.py
+++ b/adb/adb_protocol.py
@@ -460,7 +460,7 @@ class AdbMessage(object):
             delim = delim.encode('utf-8')
 
         # Delimiter may be shell@hammerhead:/ $
-        # The user or directory could change, making the delimiter somthing like root@hammerhead:/data/local/tmp $
+        # The user or directory could change, making the delimiter something like root@hammerhead:/data/local/tmp $
         # Handle a partial delimiter to search on and clean up
         if delim:
             user_pos = delim.find(b'@')


### PR DESCRIPTION
There is a small typo in adb/adb_protocol.py.

Should read `something` rather than `somthing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md